### PR TITLE
Add SPM support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.6
+
+import PackageDescription
+
+let package = Package(
+    name: "LEActivityIndicator",
+    platforms: [.iOS(.v13), .macCatalyst(.v13)],
+    products: [
+        .library(name: "LEActivityIndicator", targets: ["LEActivityIndicator"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "LEActivityIndicator", path: "Classes"),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,31 @@ let indicator = LEActivityIndicatorView(style: style, size: size, colorSet: colo
 
 ## Installation
 
+#### Swift Package Manager
+
+You can add the framework directly to your Project in Xcode in the `Package Dependencies` section. Or, as a dependency of a package in your `Package.swift` file:
+
+```swift
+// ...
+
+let package = Package(
+    // ...Rest of the properties...
+    dependencies: [
+        .package(url: "https://github.com/Hank2354/LEActivityIndicator", branch: "main"),
+    ],
+    targets: [
+        .target(
+            name: "MyPackage",
+            dependencies: [
+                .product(name: "LEActivityIndicator", package: "LEActivityIndicator"),
+            ],
+            path: "Sources"
+        ),
+    ]
+)
+
+```
+
 #### Cocoapods
 
 [Cocoapods](https://cocoapods.org/#install) is a dependency manager for Swift and Objective-C Cocoa projects. To use LEActivityIndicator with CocoaPods, add it in your `Podfile`.


### PR DESCRIPTION
Hi!

I found your repo and thought your indicators looked pretty good 😄 . I wanted to use them through SPM so I created a basic `Package.swift` file to support it.

Only a couple notes:
- I was only able to test this with Xcode 14 (currently in beta) as I only have a Ventura machine.
- Currently it has to be used pointing at the `main` branch. Perhaps you could create a git tag to keep the version in sync with the podspec?

Cheers!